### PR TITLE
Merging `$data` with `$fields` to support FCM properly

### DIFF
--- a/src/Push.php
+++ b/src/Push.php
@@ -197,10 +197,9 @@ class Push extends Component
         }
 
         if (!empty($id)) {
-            $fields = [
+            $fields = array_merge([
                 'registration_ids' => $id,
-                'data' => $data
-            ];
+            ], $data);
 
             $curl = curl_init();
             curl_setopt($curl, CURLOPT_URL, self::GCM_URL);


### PR DESCRIPTION
Allowing to provide proper structure to FCM service. Before all the payload was wrapped with `data` property, which makes impossible to send proper payload structure, where `notification` property should be in the root of payload.
The payload for android should look like this: 
```
{  
   "registration_ids":[  
      "fzdtQx55LPU:APA91bFrwA7NgsKlgTkpYD_uVVPe5hTO8OLISpNvAU5Q_u4bdUU3q0jo8Cf-2-JNOvq-xhK9TawLM7nZ5KOH3hOQUjYLy9sO4vHNbcpU0Yex3EgS5W2YXws8olK-3NWlKmLAtPSu2thM"
   ],
   "notification":{  
      "body":"Body for app in background",
      "title":"Title for app in background",
      "icon":"1",
      "sound":1,
      "priority":"high"
   },
   "data":{  
      "body":"Body for app in foreground",
      "title":"Title for app in foreground",
   }
}
```